### PR TITLE
Fix build warnings & errors for project stub

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
         android:label="bmi_calculator"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -27,13 +26,13 @@
                  until Flutter renders its first frame. It can be removed if
                  there is no splash screen (such as the default splash screen
                  defined in @style/LaunchTheme). -->
-            <meta-data
-                android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
-                android:value="true" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <meta-data
+                android:name="flutterEmbedding"
+                android:value="2" />
         </activity>
     </application>
 </manifest>

--- a/android/app/src/main/java/co/appbrewery/bmicalculator/MainActivity.java
+++ b/android/app/src/main/java/co/appbrewery/bmicalculator/MainActivity.java
@@ -1,13 +1,6 @@
 package co.appbrewery.bmicalculator;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.embedding.android.FlutterActivity;
 
 public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-  }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip


### PR DESCRIPTION
This pull request fixes 2 build issues:

1. It migrates the Android code away from deprecated embedding code to embedding v2 as recommended here: https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects
2. It fixes the `Could not initialize class org.codehaus.groovy.runtime.InvokerHelper` error by bumping up gradle to the latest version.